### PR TITLE
Fix/array vals being lost in queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,10 +131,10 @@ module.exports = (bookshelf) => {
             options = this.mapKnexQuery(options, function (obj, stmt) {
                 if (!Buffer.isBuffer(stmt.value)) {
                     Object.keys(obj.orderedUuids).forEach((column) => {
-                        if (Array.isArray(stmt.value)) {
+                        if (Array.isArray(stmt.value) && (stmt.column === `${obj.tableName}.${column}` || stmt.column === column)) {
                             const stmtValues = [];
                             stmt.value.forEach((stmtValue) => {
-                                if ((stmt.column === `${obj.tableName}.${column}` || stmt.column === column) && stmtValue) {
+                                if (stmtValue) {
                                     const generatedId = bookshelf.Model.prefixedUuidToBinary(stmtValue,
                                         (obj.orderedUuids[column] ? obj.orderedUuids[column].length : null));
                                     stmtValues.push(generatedId);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-prefixed-ordered-uuid",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Support ordered UUID's prefixed with a string as properties for your Bookshelf models.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prevent overwriting query array values unless they are orderedUUid columns